### PR TITLE
Added factory functions for creating TextStyles based off existing values

### DIFF
--- a/Example/Marker.xcodeproj/project.pbxproj
+++ b/Example/Marker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2FC3E7E41F0FC57E0024E2D1 /* TextStyleFactoryFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC3E7E21F0FC5500024E2D1 /* TextStyleFactoryFunctionTests.swift */; };
 		4811C04D1D0B6FB5007279CB /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811C04C1D0B6FB5007279CB /* AppTheme.swift */; };
 		485ED1131D09E89F00119D5D /* AvenirNextFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485ED1121D09E89F00119D5D /* AvenirNextFont.swift */; };
 		485ED1181D0A091800119D5D /* ThemeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485ED1171D0A091800119D5D /* ThemeSettingsViewController.swift */; };
@@ -38,6 +39,7 @@
 		08F1825B7EA29E36898092FB /* Marker.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Marker.podspec; path = ../Marker.podspec; sourceTree = "<group>"; };
 		1E6E60D0D2F5667C8156B123 /* Pods_Marker_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Marker_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2408A1D80FB40943D0B15C58 /* Pods-Marker_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Marker_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Marker_Tests/Pods-Marker_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		2FC3E7E21F0FC5500024E2D1 /* TextStyleFactoryFunctionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStyleFactoryFunctionTests.swift; sourceTree = "<group>"; };
 		31D2DC9BD8B466270B5299FF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		4811C04C1D0B6FB5007279CB /* AppTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		485ED1121D09E89F00119D5D /* AvenirNextFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvenirNextFont.swift; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				486EC7691DB440D3009BCA7A /* ParserTests.swift */,
+				2FC3E7E21F0FC5500024E2D1 /* TextStyleFactoryFunctionTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -415,6 +418,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				486EC76B1DB440E8009BCA7A /* ParserTests.swift in Sources */,
+				2FC3E7E41F0FC57E0024E2D1 /* TextStyleFactoryFunctionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Marker.xcodeproj/project.pbxproj
+++ b/Example/Marker.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2FC3E7E41F0FC57E0024E2D1 /* TextStyleFactoryFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC3E7E21F0FC5500024E2D1 /* TextStyleFactoryFunctionTests.swift */; };
+		2FC3E7E71F0FFB2B0024E2D1 /* TextStyleEquatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC3E7E51F0FFB220024E2D1 /* TextStyleEquatableTests.swift */; };
+		2FC3E7EA1F0FFEF90024E2D1 /* TextTransformEquatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FC3E7E81F0FFEEC0024E2D1 /* TextTransformEquatableTests.swift */; };
 		4811C04D1D0B6FB5007279CB /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811C04C1D0B6FB5007279CB /* AppTheme.swift */; };
 		485ED1131D09E89F00119D5D /* AvenirNextFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485ED1121D09E89F00119D5D /* AvenirNextFont.swift */; };
 		485ED1181D0A091800119D5D /* ThemeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485ED1171D0A091800119D5D /* ThemeSettingsViewController.swift */; };
@@ -40,6 +42,8 @@
 		1E6E60D0D2F5667C8156B123 /* Pods_Marker_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Marker_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2408A1D80FB40943D0B15C58 /* Pods-Marker_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Marker_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Marker_Tests/Pods-Marker_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		2FC3E7E21F0FC5500024E2D1 /* TextStyleFactoryFunctionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStyleFactoryFunctionTests.swift; sourceTree = "<group>"; };
+		2FC3E7E51F0FFB220024E2D1 /* TextStyleEquatableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStyleEquatableTests.swift; sourceTree = "<group>"; };
+		2FC3E7E81F0FFEEC0024E2D1 /* TextTransformEquatableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextTransformEquatableTests.swift; sourceTree = "<group>"; };
 		31D2DC9BD8B466270B5299FF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		4811C04C1D0B6FB5007279CB /* AppTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		485ED1121D09E89F00119D5D /* AvenirNextFont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvenirNextFont.swift; sourceTree = "<group>"; };
@@ -175,7 +179,9 @@
 			isa = PBXGroup;
 			children = (
 				486EC7691DB440D3009BCA7A /* ParserTests.swift */,
+				2FC3E7E51F0FFB220024E2D1 /* TextStyleEquatableTests.swift */,
 				2FC3E7E21F0FC5500024E2D1 /* TextStyleFactoryFunctionTests.swift */,
+				2FC3E7E81F0FFEEC0024E2D1 /* TextTransformEquatableTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -417,7 +423,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FC3E7EA1F0FFEF90024E2D1 /* TextTransformEquatableTests.swift in Sources */,
 				486EC76B1DB440E8009BCA7A /* ParserTests.swift in Sources */,
+				2FC3E7E71F0FFB2B0024E2D1 /* TextStyleEquatableTests.swift in Sources */,
 				2FC3E7E41F0FC57E0024E2D1 /* TextStyleFactoryFunctionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Tests/ParserTests.swift
+++ b/Example/Tests/ParserTests.swift
@@ -60,24 +60,42 @@ class ParserTests: XCTestCase {
         }
     }
     
+    func testParseUnderlinedElements() {
+        do {
+            let (parsedString, parsedElements) = try MarkdownParser.parse("==abc== def ==ghi==")
+            
+            XCTAssert(parsedString == "abc def ghi")
+            XCTAssert(parsedElements.count == 2)
+            
+            parsedElements.forEach { XCTAssert($0.isUnderlinedElement()) }
+            
+            XCTAssert(parsedElements[0].range == parsedString.range(of: "abc"))
+            XCTAssert(parsedElements[1].range == parsedString.range(of: "ghi"))
+        } catch {
+            XCTFail("Parsing failed.")
+        }
+    }
+    
     func testParseMixedElements() {
         do {
-            let (parsedString, parsedElements) = try MarkdownParser.parse("*abc* __def__ _ghi_ **jkl** ~~mno~~")
+            let (parsedString, parsedElements) = try MarkdownParser.parse("*abc* __def__ _ghi_ **jkl** ~~mno~~ ==pqr==")
             
-            XCTAssert(parsedString == "abc def ghi jkl mno")
-            XCTAssert(parsedElements.count == 5)
+            XCTAssert(parsedString == "abc def ghi jkl mno pqr")
+            XCTAssert(parsedElements.count == 6)
             
             XCTAssert(parsedElements[0].isEmElement())
             XCTAssert(parsedElements[1].isStrongElement())
             XCTAssert(parsedElements[2].isEmElement())
             XCTAssert(parsedElements[3].isStrongElement())
             XCTAssert(parsedElements[4].isStrikethroughElement())
+            XCTAssert(parsedElements[5].isUnderlinedElement())
             
             XCTAssert(parsedElements[0].range == parsedString.range(of: "abc"))
             XCTAssert(parsedElements[1].range == parsedString.range(of: "def"))
             XCTAssert(parsedElements[2].range == parsedString.range(of: "ghi"))
             XCTAssert(parsedElements[3].range == parsedString.range(of: "jkl"))
             XCTAssert(parsedElements[4].range == parsedString.range(of: "mno"))
+            XCTAssert(parsedElements[5].range == parsedString.range(of: "pqr"))
         } catch {
             XCTFail("Parsing failed.")
         }
@@ -116,22 +134,35 @@ class ParserTests: XCTestCase {
         }
     }
     
+    func testLiteralEqual() {
+        do {
+            let (parsedString, parsedElements) = try MarkdownParser.parse("two + two = four")
+            
+            XCTAssert(parsedString == "two + two = four")
+            XCTAssert(parsedElements.count == 0)
+        } catch {
+            XCTFail("Parsing failed.")
+        }
+    }
+    
     func testElementsInMiddleOfWords() {
         do {
-            let (parsedString, parsedElements) = try MarkdownParser.parse("the_quick_brown*fox*jumps__over__the**lazy**dog.")
+            let (parsedString, parsedElements) = try MarkdownParser.parse("the_quick_brown*fox*jumps__over__the**lazy**==dog==.")
             
             XCTAssert(parsedString == "thequickbrownfoxjumpsoverthelazydog.")
-            XCTAssert(parsedElements.count == 4)
+            XCTAssert(parsedElements.count == 5)
             
             XCTAssert(parsedElements[0].isEmElement())
             XCTAssert(parsedElements[1].isEmElement())
             XCTAssert(parsedElements[2].isStrongElement())
             XCTAssert(parsedElements[3].isStrongElement())
+            XCTAssert(parsedElements[4].isUnderlinedElement())
             
             XCTAssert(parsedElements[0].range == parsedString.range(of: "quick"))
             XCTAssert(parsedElements[1].range == parsedString.range(of: "fox"))
             XCTAssert(parsedElements[2].range == parsedString.range(of: "over"))
             XCTAssert(parsedElements[3].range == parsedString.range(of: "lazy"))
+            XCTAssert(parsedElements[4].range == parsedString.range(of: "dog"))
         } catch {
             XCTFail("Parsing failed.")
         }
@@ -163,6 +194,12 @@ class ParserTests: XCTestCase {
         } catch {
             XCTAssert(error as! ElementParser.ParserError == ElementParser.ParserError.unclosedTags)
         }
+        
+        do {
+            let _ = try MarkdownParser.parse("Not ==correct.")
+        } catch {
+            XCTAssert(error as! ElementParser.ParserError == ElementParser.ParserError.unclosedTags)
+        }
     }
     
 }
@@ -190,6 +227,15 @@ private extension MarkdownElement {
     func isStrikethroughElement() -> Bool {
         switch self {
         case .strikethrough(_):
+            return true
+        default:
+            return false
+        }
+    }
+    
+    func isUnderlinedElement() -> Bool {
+        switch self {
+        case .underline(_):
             return true
         default:
             return false

--- a/Example/Tests/TextStyleEquatableTests.swift
+++ b/Example/Tests/TextStyleEquatableTests.swift
@@ -1,0 +1,110 @@
+//
+//  TextStyleEquatableTests.swift
+//  Marker
+//
+//  Created by Harlan Kellaway on 7/7/17.
+//
+//
+
+import UIKit
+import XCTest
+@testable import Marker
+
+class TextStyleEquatableTests: XCTestCase {
+    
+    var textStyle: TextStyle!
+    
+    override func setUp() {
+        super.setUp()
+     
+        textStyle = TextStyle(font: UIFont(name: "Helvetica", size: 10)!,
+                              emFont: UIFont(name: "Helvetica-Oblique", size: 10)!,
+                              strongFont: UIFont(name: "Helvetica-Bold", size: 10)!,
+                              textColor: UIColor.red,
+                              characterSpacing: 1,
+                              lineSpacing: 2,
+                              lineHeightMultiple: 3,
+                              minimumLineHeight: 4,
+                              maximumLineHeight: 5,
+                              firstLineHeadIndent: 6,
+                              headIndent: 7,
+                              paragraphSpacing: 8,
+                              paragraphSpacingBefore: 9,
+                              textAlignment: .left,
+                              lineBreakMode: .byWordWrapping,
+                              strikethroughStyle: .styleSingle,
+                              strikethroughColor: UIColor.red,
+                              textTransform: .lowercased)
+    }
+    
+    override func tearDown() {
+        textStyle = nil
+        
+        super.tearDown()
+    }
+
+    func testTextStyle_isEqual_whenAllPropertiesTheSame() {
+        let sameTextStyle = TextStyle(font: textStyle.font,
+                                      emFont: textStyle.emFont,
+                                      strongFont: textStyle.strongFont,
+                                      textColor: textStyle.textColor,
+                                      characterSpacing: textStyle.characterSpacing,
+                                      lineSpacing: textStyle.lineSpacing,
+                                      lineHeightMultiple: textStyle.lineHeightMultiple,
+                                      minimumLineHeight: textStyle.minimumLineHeight,
+                                      maximumLineHeight: textStyle.maximumLineHeight,
+                                      firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                      headIndent: textStyle.headIndent,
+                                      paragraphSpacing: textStyle.paragraphSpacing,
+                                      paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                      textAlignment: textStyle.textAlignment,
+                                      lineBreakMode: textStyle.lineBreakMode,
+                                      strikethroughStyle: textStyle.strikethroughStyle,
+                                      strikethroughColor: textStyle.strikethroughColor,
+                                      textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(textStyle, sameTextStyle)
+    }
+    
+    func testTextStyle_isNotEqual_whenPropertiesAreDiffernt() {
+        let differentFont = textStyle.with(newFont: textStyle.font.withSize(textStyle.font.pointSize + 10))
+        let differentEmFont = textStyle.with(newEmFont: textStyle.emFont.withSize(textStyle.emFont.pointSize + 10))
+        let differentStrongFont = textStyle.with(newStrongFont: textStyle.strongFont.withSize(textStyle.strongFont.pointSize + 10))
+        let differentTextColor = textStyle.with(newTextColor: UIColor.blue)
+        let differentCharacterSpacing = textStyle.with(newCharacterSpacing: textStyle.characterSpacing! + 10)
+        let differentLineSpacing = textStyle.with(newLineSpacing: textStyle.lineSpacing! + 10)
+        let differentLineHeightMultiple = textStyle.with(newLineHeightMultiple: textStyle.lineHeightMultiple! + 10)
+        let differentMinimumLineHeight = textStyle.with(newMinimumLineHeight: textStyle.minimumLineHeight! + 10)
+        let differentMaximumLineHeight = textStyle.with(newMaximumLineHeight: textStyle.maximumLineHeight! + 10)
+        let differentFirstLineHeadIndent = textStyle.with(newFirstLineHeadIndent: textStyle.firstLineHeadIndent! + 10)
+        let differentHeadIndent = textStyle.with(newHeadIndent: textStyle.headIndent! + 10)
+        let differentParagraphSpacing = textStyle.with(newParagraphSpacing: textStyle.paragraphSpacing! + 10)
+        let differentParagraphSpacingBefore = textStyle.with(newParagraphSpacingBefore: textStyle.paragraphSpacingBefore! + 10)
+        let differentTextAlignment = textStyle.with(newTextAlignment: .right)
+        let differentLineBreakMode = textStyle.with(newLineBreakMode: .byCharWrapping)
+        let differentStrikethroughStyle = textStyle.with(newStrikethroughStyle: .styleDouble)
+        let differentStrikethroughColor = textStyle.with(newStrikethroughColor: UIColor.blue)
+        let differentTextTransform = textStyle.with(newTextTransform: .uppercased)
+        
+        
+        XCTAssertNotEqual(textStyle, differentFont)
+        XCTAssertNotEqual(textStyle, differentEmFont)
+        XCTAssertNotEqual(textStyle, differentStrongFont)
+        XCTAssertNotEqual(textStyle, differentTextColor)
+        XCTAssertNotEqual(textStyle, differentCharacterSpacing)
+        XCTAssertNotEqual(textStyle, differentLineSpacing)
+        XCTAssertNotEqual(textStyle, differentLineHeightMultiple)
+        XCTAssertNotEqual(textStyle, differentMinimumLineHeight)
+        XCTAssertNotEqual(textStyle, differentMaximumLineHeight)
+        XCTAssertNotEqual(textStyle, differentFirstLineHeadIndent)
+        XCTAssertNotEqual(textStyle, differentHeadIndent)
+        XCTAssertNotEqual(textStyle, differentParagraphSpacing)
+        XCTAssertNotEqual(textStyle, differentParagraphSpacingBefore)
+        XCTAssertNotEqual(textStyle, differentTextAlignment)
+        XCTAssertNotEqual(textStyle, differentLineBreakMode)
+        XCTAssertNotEqual(textStyle, differentStrikethroughStyle)
+        XCTAssertNotEqual(textStyle, differentStrikethroughColor)
+        XCTAssertNotEqual(textStyle, differentTextTransform)
+    }
+    
+}

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -664,4 +664,60 @@ class TextStyleFactoryFunctionTests: XCTestCase {
         XCTAssertEqual(newTextStyle, expectedTextStyle)
     }
     
+    func testTextStyleFactory_whenUnderlined_underlinePropertiesAreSet() {
+        let underlineStyle: NSUnderlineStyle = .styleDouble
+        let underlineColor = UIColor.green
+        let newTextStyle = textStyle.underlined(color: underlineColor, style: underlineStyle)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: underlineStyle,
+                                          underlineColor: underlineColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenUnderlined_defaultsToSingleLineOfSameColor() {
+        let expectedStyle: NSUnderlineStyle = .styleSingle
+        let expectedColor = textStyle.textColor
+        let newTextStyle = textStyle.underlined()
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: expectedStyle,
+                                          underlineColor: expectedColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
 }

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -34,6 +34,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                               lineBreakMode: .byWordWrapping,
                               strikethroughStyle: .styleSingle,
                               strikethroughColor: UIColor.red,
+                              underlineStyle: .styleSingle,
+                              underlineColor: UIColor.red,
                               textTransform: .lowercased)
     }
     
@@ -63,6 +65,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -88,6 +92,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -113,6 +119,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -138,6 +146,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -163,6 +173,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -188,6 +200,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -213,6 +227,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -238,6 +254,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -263,6 +281,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -288,6 +308,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -313,6 +335,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -338,6 +362,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -363,6 +389,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -388,6 +416,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -413,6 +443,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: newLineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -438,6 +470,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: newStrikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -463,6 +497,62 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: newStrikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewUnderlineStyle_newUnderlineStyleIsUsed() {
+        let newUnderlineStyle: NSUnderlineStyle = .styleDouble
+        let newTextStyle = textStyle.with(newUnderlineStyle: newUnderlineStyle)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: newUnderlineStyle,
+                                          underlineColor: textStyle.underlineColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewUnderlineColor_newUnderlineColorIsUsed() {
+        let newUnderlineColor = UIColor.blue
+        let newTextStyle = textStyle.with(newUnderlineColor: newUnderlineColor)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: newUnderlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -488,6 +578,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: newTextTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -513,6 +605,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -537,6 +631,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -561,6 +657,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -493,4 +493,52 @@ class TextStyleFactoryFunctionTests: XCTestCase {
         XCTAssertEqual(newTextStyle, expectedTextStyle)
     }
     
+    func testTextStyleFactory_whenBolded_fontIsBold() {
+        let newTextStyle = textStyle.bold()
+        let expectedTextStyle = TextStyle(font: textStyle.strongFont,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+
+    func testTextStyleFactory_whenItalicized_fontIsitalic() {
+        let newTextStyle = textStyle.italic()
+        let expectedTextStyle = TextStyle(font: textStyle.emFont,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
 }

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -1,0 +1,496 @@
+//
+//  TextStyleFactoryFunctionTests.swift
+//  Marker
+//
+//  Created by Harlan Kellaway on 7/7/17.
+//
+//
+
+import UIKit
+import XCTest
+@testable import Marker
+
+class TextStyleFactoryFunctionTests: XCTestCase {
+    
+    var textStyle: TextStyle!
+    
+    override func setUp() {
+        super.setUp()
+        
+        textStyle = TextStyle(font: UIFont(name: "Helvetica", size: 10)!,
+                              emFont: UIFont(name: "Helvetica-Oblique", size: 10)!,
+                              strongFont: UIFont(name: "Helvetica-Bold", size: 10)!,
+                              textColor: UIColor.red,
+                              characterSpacing: 1,
+                              lineSpacing: 2,
+                              lineHeightMultiple: 3,
+                              minimumLineHeight: 4,
+                              maximumLineHeight: 5,
+                              firstLineHeadIndent: 6,
+                              headIndent: 7,
+                              paragraphSpacing: 8,
+                              paragraphSpacingBefore: 9,
+                              textAlignment: .left,
+                              lineBreakMode: .byWordWrapping,
+                              strikethroughStyle: .styleSingle,
+                              strikethroughColor: UIColor.red,
+                              textTransform: .lowercased)
+    }
+    
+    override func tearDown() {
+        textStyle = nil
+        
+        super.tearDown()
+    }
+
+    func testTextStyleFactory_whenNewFont_newFontIsUsed() {
+        let newFont = textStyle.font.withSize(textStyle.font.pointSize + 10)
+        let newTextStyle = textStyle.with(newFont: newFont)
+        let expectedTextStyle = TextStyle(font: newFont,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewEmFont_newEmFontIsUsed() {
+        let newEmFont = textStyle.emFont.withSize(textStyle.emFont.pointSize + 10)
+        let newTextStyle = textStyle.with(newEmFont: newEmFont)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: newEmFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewStrongFont_newStrongFontIsUsed() {
+        let newStrongFont = textStyle.strongFont.withSize(textStyle.strongFont.pointSize + 10)
+        let newTextStyle = textStyle.with(newStrongFont: newStrongFont)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: newStrongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewTextColor_newTextColorIsUsed() {
+        let newTextColor = UIColor.blue
+        let newTextStyle = textStyle.with(newTextColor: newTextColor)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: newTextColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewCharacterSpacing_newCharacterIsUsed() {
+        let newCharacterSpacing = textStyle.characterSpacing! + 10
+        let newTextStyle = textStyle.with(newCharacterSpacing: newCharacterSpacing)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: newCharacterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewLineSpacing_newLineSpacingIsUsed() {
+        let newLineSpacing = textStyle.lineSpacing! + 10
+        let newTextStyle = textStyle.with(newLineSpacing: newLineSpacing)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: newLineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewLineHeightMultiple_newLineHeightMultipleIsUsed() {
+        let newLineHeightMultiple = textStyle.lineHeightMultiple! + 10
+        let newTextStyle = textStyle.with(newLineHeightMultiple: newLineHeightMultiple)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: newLineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewMinimumLineHeight_newMinimumLineHeightIsUsed() {
+        let newMinimumLineHeight = textStyle.minimumLineHeight! + 10
+        let newTextStyle = textStyle.with(newMinimumLineHeight: newMinimumLineHeight)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: newMinimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewMaximumLineHeight_newMaximumLineHeightIsUsed() {
+        let newMaximumLineHeight = textStyle.maximumLineHeight! + 10
+        let newTextStyle = textStyle.with(newMaximumLineHeight: newMaximumLineHeight)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: newMaximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewFirstLineHeadIndent_newFirstLineHeadIndentIsUsed() {
+        let newFirstLineHeadIndent = textStyle.firstLineHeadIndent! + 10
+        let newTextStyle = textStyle.with(newFirstLineHeadIndent: newFirstLineHeadIndent)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: newFirstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewHeadIndent_newHeadIndentIsUsed() {
+        let newHeadIndent = textStyle.headIndent! + 10
+        let newTextStyle = textStyle.with(newHeadIndent: newHeadIndent)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: newHeadIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewParagraphSpacing_newParagraphSpacingIsUsed() {
+        let newParagraphSpacing = textStyle.paragraphSpacing! + 10
+        let newTextStyle = textStyle.with(newParagraphSpacing: newParagraphSpacing)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: newParagraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewParagraphSpacingBefore_newParagraphSpacingBeforeIsUsed() {
+        let newParagraphSpacingBefore = textStyle.paragraphSpacingBefore! + 10
+        let newTextStyle = textStyle.with(newParagraphSpacingBefore: newParagraphSpacingBefore)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: newParagraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewTextAlignment_newTextAlignmentIsUsed() {
+        let newTextAlignment: NSTextAlignment = .right
+        let newTextStyle = textStyle.with(newTextAlignment: newTextAlignment)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: newTextAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewLineBreakMode_newLineBreakModeIsUsed() {
+        let newLineBreakMode: NSLineBreakMode = .byCharWrapping
+        let newTextStyle = textStyle.with(newLineBreakMode: newLineBreakMode)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: newLineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewStrikethroughStyle_newStrikethroughStyleIsUsed() {
+        let newStrikethroughStyle: NSUnderlineStyle = .styleDouble
+        let newTextStyle = textStyle.with(newStrikethroughStyle: newStrikethroughStyle)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: newStrikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewStrikethroughColor_newStrikethroughColorIsUsed() {
+        let newStrikethroughColor = UIColor.blue
+        let newTextStyle = textStyle.with(newStrikethroughColor: newStrikethroughColor)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: newStrikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewTextTransform_newTextTransformIsUsed() {
+        let newTextTransform: TextTransform = .uppercased
+        let newTextStyle = textStyle.with(newTextTransform: newTextTransform)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: newTextTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+}

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -493,6 +493,31 @@ class TextStyleFactoryFunctionTests: XCTestCase {
         XCTAssertEqual(newTextStyle, expectedTextStyle)
     }
     
+    func testTextStyleFactory_whenNewFontSize_allFontsHaveNewSize() {
+        let newFontSize = textStyle.font.pointSize + 10
+        let newTextStyle = textStyle.with(newFontSize: newFontSize)
+        let expectedTextStyle = TextStyle(font: textStyle.font.withSize(newFontSize),
+                                          emFont: textStyle.emFont.withSize(newFontSize),
+                                          strongFont: textStyle.strongFont.withSize(newFontSize),
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
     func testTextStyleFactory_whenBolded_fontIsBold() {
         let newTextStyle = textStyle.bold()
         let expectedTextStyle = TextStyle(font: textStyle.strongFont,

--- a/Example/Tests/TextTransformEquatableTests.swift
+++ b/Example/Tests/TextTransformEquatableTests.swift
@@ -1,0 +1,33 @@
+//
+//  TextTransformEquatableTests.swift
+//  Marker
+//
+//  Created by Harlan Kellaway on 7/7/17.
+//
+//
+
+import UIKit
+import XCTest
+@testable import Marker
+
+class TextTransformEquatableTests: XCTestCase {
+
+    func testTextStyle_isEqual_whenSameValue_andNotCustom() {
+        let none: TextTransform = .none
+        let lowercased: TextTransform = .lowercased
+        let uppercased: TextTransform = .uppercased
+        let capitalized: TextTransform = .capitalized
+        
+        XCTAssertEqual(none, none)
+        XCTAssertEqual(lowercased, lowercased)
+        XCTAssertEqual(uppercased, uppercased)
+        XCTAssertEqual(capitalized, capitalized)
+    }
+    
+    func testTextStyle_isNotEqual_whenCustom() {
+        let custom: TextTransform = .custom({ string in "\(string) \(string)" })
+        
+        XCTAssertNotEqual(custom, custom)
+    }
+    
+}

--- a/Marker/Classes/Marker.swift
+++ b/Marker/Classes/Marker.swift
@@ -61,6 +61,7 @@ public func parsedMarkdownString(from markdownText: String,
     elements.forEach { (element) in
         var font: UIFont? = nil
         var strikethroughStyle: NSUnderlineStyle? = nil
+        var underlineStyle: NSUnderlineStyle? = nil
         
         switch element {
         case .em(_):
@@ -69,6 +70,8 @@ public func parsedMarkdownString(from markdownText: String,
             font = textStyle.strongFont
         case .strikethrough(_):
             strikethroughStyle = textStyle.strikethroughStyle
+        case .underline(_):
+            underlineStyle = textStyle.underlineStyle
         }
         
         if let font = font {
@@ -82,6 +85,14 @@ public func parsedMarkdownString(from markdownText: String,
             if let strikethroughColor = textStyle.strikethroughColor {
                 attributedString.addAttributes([NSStrikethroughColorAttributeName: strikethroughColor],
                                                range: parsedString.range(from: element.range))
+            }
+        }
+        
+        if let underlineStyle = underlineStyle {
+            attributedString.addAttributes([NSUnderlineStyleAttributeName: underlineStyle.rawValue], range: parsedString.range(from: element.range))
+            
+            if let underlineColor = textStyle.underlineColor {
+                attributedString.addAttributes([NSUnderlineColorAttributeName: underlineColor], range: parsedString.range(from: element.range))
             }
         }
     }

--- a/Marker/Classes/Parser/MarkdownElement.swift
+++ b/Marker/Classes/Parser/MarkdownElement.swift
@@ -13,11 +13,13 @@ import Foundation
 /// - em: Emphasis element.
 /// - strong: Strong element.
 /// - strikethrough: Strikethrough element.
+/// - underline: Underline element.
 internal enum MarkdownElement {
     
     case em(Range<Index>)
     case strong(Range<Index>)
     case strikethrough(Range<Index>)
+    case underline(Range<Index>)
     
     /// Range of characters that the elements apply to.
     var range: Range<Index> {
@@ -27,6 +29,8 @@ internal enum MarkdownElement {
         case .strong(let range):
             return range
         case .strikethrough(let range):
+            return range
+        case .underline(let range):
             return range
         }
     }

--- a/Marker/Classes/Parser/MarkdownParser.swift
+++ b/Marker/Classes/Parser/MarkdownParser.swift
@@ -27,6 +27,7 @@ internal struct MarkdownParser {
     private static let underscoreStrongSymbol = Symbol(rawValue: "__")
     private static let asteriskStrongSymbol = Symbol(rawValue: "**")
     private static let tildeStrikethroughSymbol = Symbol(rawValue: "~~")
+    private static let equalUnderlineSymbol = Symbol(rawValue: "==")
     
     // MARK: - Static functions
     
@@ -41,7 +42,8 @@ internal struct MarkdownParser {
             let asteriskEmSymbol = asteriskEmSymbol,
             let underscoreStrongSymbol = underscoreStrongSymbol,
             let asteriskStrongSymbol = asteriskStrongSymbol,
-            let tildeStrikethroughSymbol = tildeStrikethroughSymbol else {
+            let tildeStrikethroughSymbol = tildeStrikethroughSymbol,
+            let equalUnderlineSymbol = equalUnderlineSymbol else {
                 return (string, [])
         }
         
@@ -53,6 +55,8 @@ internal struct MarkdownParser {
                 return .strong(element.range)
             case tildeStrikethroughSymbol:
                 return .strikethrough(element.range)
+            case equalUnderlineSymbol:
+                return .underline(element.range)
             default:
                 throw ParserError.invalidTagSymbol
             }
@@ -63,7 +67,8 @@ internal struct MarkdownParser {
                                                                        asteriskEmSymbol,
                                                                        underscoreStrongSymbol,
                                                                        asteriskStrongSymbol,
-                                                                       tildeStrikethroughSymbol])
+                                                                       tildeStrikethroughSymbol,
+                                                                       equalUnderlineSymbol])
         return try (strippedString, elements.map(transformToMarkdownElement))
     }
     

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -11,10 +11,28 @@ import UIKit
 /// Adds factory functions producing new TextStyle from existing TextStyle.
 public extension TextStyle {
     
-    /// Creates new TextStyle from exisiting TextStyle, updating with provided values.Creates
+    /// Creates new TextStyle from exisiting TextStyle, updating with provided values.
     ///
-    /// - Parameter newFont: New font to use.
-    /// - Returns: New TextStyle.
+    /// - Parameters:
+    ///   - newFont: New font.
+    ///   - newEmFont: New emphasis font.
+    ///   - newStrongFont: New strong font.
+    ///   - newTextColor: New text color.
+    ///   - newCharacterSpacing: New character spacing.
+    ///   - newLineSpacing: New line spacing.
+    ///   - newLineHeightMultiple: New line height multiple.
+    ///   - newMinimumLineHeight: New minimum line height.
+    ///   - newMaximumLineHeight: New maximum line height.
+    ///   - newFirstLineHeadIndent: New first line head indent.
+    ///   - newHeadIndent: New head indent.
+    ///   - newParagraphSpacing: New paragraph spacing.
+    ///   - newParagraphSpacingBefore: New paragraph spacing before.
+    ///   - newTextAlignment: New text alignment.
+    ///   - newLineBreakMode: New line break mode.
+    ///   - newStrikethroughStyle: New strikethrough style.
+    ///   - newStrikethroughColor: New strikethrough color.
+    ///   - newTextTransform: New text transform.
+    /// - Returns: New Text Style with updated value(s).
     public func with(newFont: UIFont? = nil,
                      newEmFont: UIFont? = nil,
                      newStrongFont: UIFont? = nil,
@@ -72,6 +90,20 @@ public extension TextStyle {
             strikethroughColor: strikethroughColorToUse,
             textTransform: textTransformToUse
         )
+    }
+    
+    /// Creates new TextStyle from exisiting TextStyle, replacing font with bold variation.
+    ///
+    /// - Returns: New TextStyle with updated font.
+    public func bold() -> TextStyle {
+        return self.with(newFont: strongFont)
+    }
+    
+    /// Creates new TextStyle from exisiting TextStyle, replacing font with italic variation.
+    ///
+    /// - Returns: New TextStyle with updated font.
+    public func italic() -> TextStyle {
+        return self.with(newFont: emFont)
     }
     
 }

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -92,6 +92,18 @@ public extension TextStyle {
         )
     }
     
+    /// Creates new TextStyle from exisiting TextStyle, updating fonts with new size.
+    ///
+    /// - Parameter newFontSize: New font size.
+    /// - Returns: New TextStyle.
+    public func with(newFontSize: CGFloat) -> TextStyle {
+        return self.with(
+            newFont: self.font.withSize(newFontSize),
+            newEmFont: self.emFont.withSize(newFontSize),
+            newStrongFont: self.strongFont.withSize(newFontSize)
+        )
+    }
+    
     /// Creates new TextStyle from exisiting TextStyle, replacing font with bold variation.
     ///
     /// - Returns: New TextStyle with updated font.

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -126,6 +126,17 @@ public extension TextStyle {
         return self.with(newFont: emFont)
     }
     
+    /// Creates new Text Style from exisiting TextStyle, with underline.
+    ///
+    /// - Parameter color: Underline color. Defaults to textColor.
+    /// - Parameter style: Underline style. Defaults to single line.
+    /// - Returns: New TextStyle with underline.
+    public func underlined(color: UIColor? = nil, style: NSUnderlineStyle = .styleSingle) -> TextStyle {
+        return self
+            .with(newUnderlineStyle: style)
+            .with(newUnderlineColor: color ?? textColor)
+    }
+    
 }
 
 // MARK: - Protocol conformance

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -1,0 +1,108 @@
+//
+//  TextStyle+Extensions.swift
+//  Marker
+//
+//  Created by Harlan Kellaway on 7/7/17.
+//  Copyright © 2017 Prolific Interactive. All rights reserved.
+//
+
+import UIKit
+
+/// Adds factory functions producing new TextStyle from existing TextStyle.
+public extension TextStyle {
+    
+    /// Creates new TextStyle from exisiting TextStyle, updating with provided values.Creates
+    ///
+    /// - Parameter newFont: New font to use.
+    /// - Returns: New TextStyle.
+    public func with(newFont: UIFont? = nil,
+                     newEmFont: UIFont? = nil,
+                     newStrongFont: UIFont? = nil,
+                     newTextColor: UIColor? = nil,
+                     newCharacterSpacing: CGFloat? = nil,
+                     newLineSpacing: CGFloat? = nil,
+                     newLineHeightMultiple: CGFloat? = nil,
+                     newMinimumLineHeight: CGFloat? = nil,
+                     newMaximumLineHeight: CGFloat? = nil,
+                     newFirstLineHeadIndent: CGFloat? = nil,
+                     newHeadIndent: CGFloat? = nil,
+                     newParagraphSpacing: CGFloat? = nil,
+                     newParagraphSpacingBefore: CGFloat? = nil,
+                     newTextAlignment: NSTextAlignment? = nil,
+                     newLineBreakMode: NSLineBreakMode? = nil,
+                     newStrikethroughStyle: NSUnderlineStyle? = nil,
+                     newStrikethroughColor: UIColor? = nil,
+                     newTextTransform: TextTransform? = nil) -> TextStyle {
+        let fontToUse = (newFont == nil) ? self.font : newFont!
+        let emFontToUse = (newEmFont == nil) ? self.emFont : newEmFont!
+        let strongFontToUse = (newStrongFont == nil) ? self.strongFont : newStrongFont!
+        let textColorToUse = (newTextColor == nil) ? self.textColor : newTextColor!
+        let characterSpacingToUse = (newCharacterSpacing == nil) ? self.characterSpacing : newCharacterSpacing!
+        let lineSpacingToUse = (newLineSpacing == nil) ? self.lineSpacing : newLineSpacing!
+        let lineHeightMultipleToUse = (newLineHeightMultiple == nil) ? self.lineHeightMultiple : newLineHeightMultiple!
+        let minimumLineHeightToUse = (newMinimumLineHeight == nil) ? self.minimumLineHeight : newMinimumLineHeight!
+        let maximumLineHeightToUse = (newMaximumLineHeight == nil) ? self.maximumLineHeight : newMaximumLineHeight!
+        let firstLineHeadIndentToUse = (newFirstLineHeadIndent == nil) ? self.firstLineHeadIndent : newFirstLineHeadIndent!
+        let headIndentToUse = (newHeadIndent == nil) ? self.headIndent : newHeadIndent!
+        let paragraphSpacingToUse = (newParagraphSpacing == nil) ? self.paragraphSpacing : newParagraphSpacing!
+        let paragraphSpacingBeforeToUse = (newParagraphSpacingBefore == nil) ? self.paragraphSpacingBefore : newParagraphSpacingBefore!
+        let textAlignmentToUse = (newTextAlignment == nil) ? self.textAlignment : newTextAlignment!
+        let lineBreakModeToUse = (newLineBreakMode == nil) ? self.lineBreakMode : newLineBreakMode!
+        let strikethroughStyleToUse = (newStrikethroughStyle == nil) ? self.strikethroughStyle : newStrikethroughStyle!
+        let strikethroughColorToUse = (newStrikethroughColor == nil) ? self.strikethroughColor : newStrikethroughColor!
+        let textTransformToUse = (newTextTransform == nil) ? self.textTransform : newTextTransform!
+        
+        return TextStyle(
+            font: fontToUse,
+            emFont: emFontToUse,
+            strongFont: strongFontToUse,
+            textColor: textColorToUse,
+            characterSpacing: characterSpacingToUse,
+            lineSpacing: lineSpacingToUse,
+            lineHeightMultiple: lineHeightMultipleToUse,
+            minimumLineHeight: minimumLineHeightToUse,
+            maximumLineHeight: maximumLineHeightToUse,
+            firstLineHeadIndent: firstLineHeadIndentToUse,
+            headIndent: headIndentToUse,
+            paragraphSpacing: paragraphSpacingToUse,
+            paragraphSpacingBefore: paragraphSpacingBeforeToUse,
+            textAlignment: textAlignmentToUse,
+            lineBreakMode: lineBreakModeToUse,
+            strikethroughStyle: strikethroughStyleToUse,
+            strikethroughColor: strikethroughColorToUse,
+            textTransform: textTransformToUse
+        )
+    }
+    
+}
+
+// MARK: - Protocol conformance
+
+// MARK: Equatable
+
+extension TextStyle: Equatable { }
+
+public func ==(lhs: TextStyle, rhs: TextStyle) -> Bool {
+    guard lhs.font == rhs.font,
+        lhs.emFont == rhs.emFont,
+        lhs.strongFont == rhs.strongFont,
+        lhs.textColor == rhs.textColor,
+        lhs.characterSpacing == rhs.characterSpacing,
+        lhs.lineSpacing == rhs.lineSpacing,
+        lhs.lineHeightMultiple == rhs.lineHeightMultiple,
+        lhs.minimumLineHeight == rhs.minimumLineHeight,
+        lhs.maximumLineHeight == rhs.maximumLineHeight,
+        lhs.firstLineHeadIndent == rhs.firstLineHeadIndent,
+        lhs.headIndent == rhs.headIndent,
+        lhs.paragraphSpacing == rhs.paragraphSpacing,
+        lhs.paragraphSpacingBefore == rhs.paragraphSpacingBefore,
+        lhs.textAlignment == rhs.textAlignment,
+        lhs.lineBreakMode == rhs.lineBreakMode,
+        lhs.strikethroughStyle == rhs.strikethroughStyle,
+        lhs.strikethroughColor == rhs.strikethroughColor,
+        lhs.textTransform == rhs.textTransform else {
+        return false
+    }
+    
+    return true
+}

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -31,6 +31,8 @@ public extension TextStyle {
     ///   - newLineBreakMode: New line break mode.
     ///   - newStrikethroughStyle: New strikethrough style.
     ///   - newStrikethroughColor: New strikethrough color.
+    ///   - newUnderlineStyle: New underline style.
+    ///   - newUnderlineColor: New underline color.
     ///   - newTextTransform: New text transform.
     /// - Returns: New Text Style with updated value(s).
     public func with(newFont: UIFont? = nil,
@@ -50,6 +52,8 @@ public extension TextStyle {
                      newLineBreakMode: NSLineBreakMode? = nil,
                      newStrikethroughStyle: NSUnderlineStyle? = nil,
                      newStrikethroughColor: UIColor? = nil,
+                     newUnderlineStyle: NSUnderlineStyle? = nil,
+                     newUnderlineColor: UIColor? = nil,
                      newTextTransform: TextTransform? = nil) -> TextStyle {
         let fontToUse = (newFont == nil) ? self.font : newFont!
         let emFontToUse = (newEmFont == nil) ? self.emFont : newEmFont!
@@ -68,6 +72,8 @@ public extension TextStyle {
         let lineBreakModeToUse = (newLineBreakMode == nil) ? self.lineBreakMode : newLineBreakMode!
         let strikethroughStyleToUse = (newStrikethroughStyle == nil) ? self.strikethroughStyle : newStrikethroughStyle!
         let strikethroughColorToUse = (newStrikethroughColor == nil) ? self.strikethroughColor : newStrikethroughColor!
+        let underlineStyleToUse = (newUnderlineStyle == nil) ? self.underlineStyle : newUnderlineStyle!
+        let underlineColorToUse = (newUnderlineColor == nil) ? self.underlineColor : newUnderlineColor!
         let textTransformToUse = (newTextTransform == nil) ? self.textTransform : newTextTransform!
         
         return TextStyle(
@@ -88,6 +94,8 @@ public extension TextStyle {
             lineBreakMode: lineBreakModeToUse,
             strikethroughStyle: strikethroughStyleToUse,
             strikethroughColor: strikethroughColorToUse,
+            underlineStyle: underlineStyleToUse,
+            underlineColor: underlineColorToUse,
             textTransform: textTransformToUse
         )
     }
@@ -144,6 +152,8 @@ public func ==(lhs: TextStyle, rhs: TextStyle) -> Bool {
         lhs.lineBreakMode == rhs.lineBreakMode,
         lhs.strikethroughStyle == rhs.strikethroughStyle,
         lhs.strikethroughColor == rhs.strikethroughColor,
+        lhs.underlineStyle == rhs.underlineStyle,
+        lhs.underlineColor == rhs.underlineColor,
         lhs.textTransform == rhs.textTransform else {
         return false
     }

--- a/Marker/Classes/TextStyle.swift
+++ b/Marker/Classes/TextStyle.swift
@@ -67,6 +67,12 @@ public struct TextStyle {
     /// Stroke color for strikethough text.
     public var strikethroughColor: UIColor?
     
+    /// Underline style for underlined text.s
+    public var underlineStyle: NSUnderlineStyle?
+    
+    /// Stroke color for underlined text.
+    public var underlineColor: UIColor?
+    
     /// Text transform.
     public var textTransform: TextTransform
     
@@ -145,6 +151,8 @@ public struct TextStyle {
      - parameter lineBreakMode:          Line break node.
      - parameter strikethroughStyle:     Strikethrough style.
      - parameter strikethroughColor:     Strikethrough color.
+     - parameter underlineStyle:         Underline style.
+     - parameter underlineColor:         Underline color.s
      - parameter textTransform:          Text transform option.
      
      - returns: An initialized text style object.
@@ -166,6 +174,8 @@ public struct TextStyle {
                 lineBreakMode: NSLineBreakMode? = nil,
                 strikethroughStyle: NSUnderlineStyle? = nil,
                 strikethroughColor: UIColor? = nil,
+                underlineStyle: NSUnderlineStyle? = nil,
+                underlineColor: UIColor? = nil,
                 textTransform: TextTransform = .none) {
         self.font = font
         self.emFont = (emFont == nil) ? font : emFont!
@@ -184,6 +194,8 @@ public struct TextStyle {
         self.lineBreakMode = lineBreakMode
         self.strikethroughStyle = strikethroughStyle
         self.strikethroughColor = strikethroughColor
+        self.underlineStyle = underlineStyle
+        self.underlineColor = underlineColor
         self.textTransform = textTransform
     }
 }

--- a/Marker/Classes/TextStyle.swift
+++ b/Marker/Classes/TextStyle.swift
@@ -152,7 +152,7 @@ public struct TextStyle {
      - parameter strikethroughStyle:     Strikethrough style.
      - parameter strikethroughColor:     Strikethrough color.
      - parameter underlineStyle:         Underline style.
-     - parameter underlineColor:         Underline color.s
+     - parameter underlineColor:         Underline color.
      - parameter textTransform:          Text transform option.
      
      - returns: An initialized text style object.

--- a/Marker/Classes/TextStyle.swift
+++ b/Marker/Classes/TextStyle.swift
@@ -67,7 +67,7 @@ public struct TextStyle {
     /// Stroke color for strikethough text.
     public var strikethroughColor: UIColor?
     
-    /// Underline style for underlined text.s
+    /// Underline style for underlined text.
     public var underlineStyle: NSUnderlineStyle?
     
     /// Stroke color for underlined text.

--- a/Marker/Classes/TextTransform+Extensions.swift
+++ b/Marker/Classes/TextTransform+Extensions.swift
@@ -22,6 +22,8 @@ public func ==(lhs: TextTransform, rhs: TextTransform) -> Bool {
         return true
     case (.uppercased, .uppercased):
         return true
+    case (.capitalized, .capitalized):
+        return true
     default:
         return false
     }

--- a/Marker/Classes/TextTransform+Extensions.swift
+++ b/Marker/Classes/TextTransform+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  TextTransform+Extensions.swift
+//  Marker
+//
+//  Created by Harlan Kellaway on 7/7/17.
+//  Copyright © 2017 Prolific Interactive. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Protocol conformance
+
+// MARK: Equatable
+
+extension TextTransform: Equatable { }
+
+public func ==(lhs: TextTransform, rhs: TextTransform) -> Bool {
+    switch (lhs, rhs) {
+    case (.none, .none):
+        return true
+    case (.lowercased, .lowercased):
+        return true
+    case (.uppercased, .uppercased):
+        return true
+    default:
+        return false
+    }
+}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Marker also supports setting text with common Markdown tags:
 
 * Bold (`__` or `**`)
 * Italic (`_` or `*`)
+
+As well as convenient Markdown tags specific to Marker:
+
 * Strikethrough (`~~`)
 * Underline (`==`)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Marker abstracts the most common attributed text properties into a data object c
 * Text alignment
 * Line break mode
 * Strikethrough style and color
+* Underline style and color
 * Text transformation option
 
 `TextStyle` objects are a simple way of aggregating style information. For example:
@@ -94,6 +95,7 @@ Marker also supports setting text with common Markdown tags:
 * Bold (`__` or `**`)
 * Italic (`_` or `*`)
 * Strikethrough (`~~`)
+* Underline (`==`)
 
 To set Markdown text on these elements, use `setMarkdownText(_:using:)` (or `setMarkdownTitleText(_:using:)` for `UIButton`) function.
 


### PR DESCRIPTION
* Added factory functions for creating new `TextStyle`s based on existing values (e.g. `textStyle.with(newTextColor:)`
* Added factory function for create `TextStyle` with new font size
* Added factory functions for creating new `TextStyle` with bold/italic as font
* Updated `TextStyle` and `TextTransform` to be `Equatable`
* Tests for factory functions and equality