### PR TITLE
Markdown tag for underline (==)

### DIFF
--- a/Example/Tests/ParserTests.swift
+++ b/Example/Tests/ParserTests.swift
@@ -60,24 +60,42 @@ class ParserTests: XCTestCase {
         }
     }
     
+    func testParseUnderlinedElements() {
+        do {
+            let (parsedString, parsedElements) = try MarkdownParser.parse("==abc== def ==ghi==")
+            
+            XCTAssert(parsedString == "abc def ghi")
+            XCTAssert(parsedElements.count == 2)
+            
+            parsedElements.forEach { XCTAssert($0.isUnderlinedElement()) }
+            
+            XCTAssert(parsedElements[0].range == parsedString.range(of: "abc"))
+            XCTAssert(parsedElements[1].range == parsedString.range(of: "ghi"))
+        } catch {
+            XCTFail("Parsing failed.")
+        }
+    }
+    
     func testParseMixedElements() {
         do {
-            let (parsedString, parsedElements) = try MarkdownParser.parse("*abc* __def__ _ghi_ **jkl** ~~mno~~")
+            let (parsedString, parsedElements) = try MarkdownParser.parse("*abc* __def__ _ghi_ **jkl** ~~mno~~ ==pqr==")
             
-            XCTAssert(parsedString == "abc def ghi jkl mno")
-            XCTAssert(parsedElements.count == 5)
+            XCTAssert(parsedString == "abc def ghi jkl mno pqr")
+            XCTAssert(parsedElements.count == 6)
             
             XCTAssert(parsedElements[0].isEmElement())
             XCTAssert(parsedElements[1].isStrongElement())
             XCTAssert(parsedElements[2].isEmElement())
             XCTAssert(parsedElements[3].isStrongElement())
             XCTAssert(parsedElements[4].isStrikethroughElement())
+            XCTAssert(parsedElements[5].isUnderlinedElement())
             
             XCTAssert(parsedElements[0].range == parsedString.range(of: "abc"))
             XCTAssert(parsedElements[1].range == parsedString.range(of: "def"))
             XCTAssert(parsedElements[2].range == parsedString.range(of: "ghi"))
             XCTAssert(parsedElements[3].range == parsedString.range(of: "jkl"))
             XCTAssert(parsedElements[4].range == parsedString.range(of: "mno"))
+            XCTAssert(parsedElements[5].range == parsedString.range(of: "pqr"))
         } catch {
             XCTFail("Parsing failed.")
         }
@@ -116,22 +134,35 @@ class ParserTests: XCTestCase {
         }
     }
     
+    func testLiteralEqual() {
+        do {
+            let (parsedString, parsedElements) = try MarkdownParser.parse("two + two = four")
+            
+            XCTAssert(parsedString == "two + two = four")
+            XCTAssert(parsedElements.count == 0)
+        } catch {
+            XCTFail("Parsing failed.")
+        }
+    }
+    
     func testElementsInMiddleOfWords() {
         do {
-            let (parsedString, parsedElements) = try MarkdownParser.parse("the_quick_brown*fox*jumps__over__the**lazy**dog.")
+            let (parsedString, parsedElements) = try MarkdownParser.parse("the_quick_brown*fox*jumps__over__the**lazy**==dog==.")
             
             XCTAssert(parsedString == "thequickbrownfoxjumpsoverthelazydog.")
-            XCTAssert(parsedElements.count == 4)
+            XCTAssert(parsedElements.count == 5)
             
             XCTAssert(parsedElements[0].isEmElement())
             XCTAssert(parsedElements[1].isEmElement())
             XCTAssert(parsedElements[2].isStrongElement())
             XCTAssert(parsedElements[3].isStrongElement())
+            XCTAssert(parsedElements[4].isUnderlinedElement())
             
             XCTAssert(parsedElements[0].range == parsedString.range(of: "quick"))
             XCTAssert(parsedElements[1].range == parsedString.range(of: "fox"))
             XCTAssert(parsedElements[2].range == parsedString.range(of: "over"))
             XCTAssert(parsedElements[3].range == parsedString.range(of: "lazy"))
+            XCTAssert(parsedElements[4].range == parsedString.range(of: "dog"))
         } catch {
             XCTFail("Parsing failed.")
         }
@@ -163,6 +194,12 @@ class ParserTests: XCTestCase {
         } catch {
             XCTAssert(error as! ElementParser.ParserError == ElementParser.ParserError.unclosedTags)
         }
+        
+        do {
+            let _ = try MarkdownParser.parse("Not ==correct.")
+        } catch {
+            XCTAssert(error as! ElementParser.ParserError == ElementParser.ParserError.unclosedTags)
+        }
     }
     
 }
@@ -190,6 +227,15 @@ private extension MarkdownElement {
     func isStrikethroughElement() -> Bool {
         switch self {
         case .strikethrough(_):
+            return true
+        default:
+            return false
+        }
+    }
+    
+    func isUnderlinedElement() -> Bool {
+        switch self {
+        case .underline(_):
             return true
         default:
             return false

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -664,4 +664,60 @@ class TextStyleFactoryFunctionTests: XCTestCase {
         XCTAssertEqual(newTextStyle, expectedTextStyle)
     }
     
+    func testTextStyleFactory_whenUnderlined_underlinePropertiesAreSet() {
+        let underlineStyle: NSUnderlineStyle = .styleDouble
+        let underlineColor = UIColor.green
+        let newTextStyle = textStyle.underlined(color: underlineColor, style: underlineStyle)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: underlineStyle,
+                                          underlineColor: underlineColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenUnderlined_defaultsToSingleLineOfSameColor() {
+        let expectedStyle: NSUnderlineStyle = .styleSingle
+        let expectedColor = textStyle.textColor
+        let newTextStyle = textStyle.underlined()
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: expectedStyle,
+                                          underlineColor: expectedColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
 }

--- a/Example/Tests/TextStyleFactoryFunctionTests.swift
+++ b/Example/Tests/TextStyleFactoryFunctionTests.swift
@@ -34,6 +34,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                               lineBreakMode: .byWordWrapping,
                               strikethroughStyle: .styleSingle,
                               strikethroughColor: UIColor.red,
+                              underlineStyle: .styleSingle,
+                              underlineColor: UIColor.red,
                               textTransform: .lowercased)
     }
     
@@ -63,6 +65,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -88,6 +92,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -113,6 +119,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -138,6 +146,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -163,6 +173,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -188,6 +200,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -213,6 +227,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -238,6 +254,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -263,6 +281,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -288,6 +308,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -313,6 +335,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -338,6 +362,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -363,6 +389,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -388,6 +416,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -413,6 +443,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: newLineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -438,6 +470,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: newStrikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -463,6 +497,62 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: newStrikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewUnderlineStyle_newUnderlineStyleIsUsed() {
+        let newUnderlineStyle: NSUnderlineStyle = .styleDouble
+        let newTextStyle = textStyle.with(newUnderlineStyle: newUnderlineStyle)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: newUnderlineStyle,
+                                          underlineColor: textStyle.underlineColor,
+                                          textTransform: textStyle.textTransform)
+        
+        XCTAssertEqual(newTextStyle, expectedTextStyle)
+    }
+    
+    func testTextStyleFactory_whenNewUnderlineColor_newUnderlineColorIsUsed() {
+        let newUnderlineColor = UIColor.blue
+        let newTextStyle = textStyle.with(newUnderlineColor: newUnderlineColor)
+        let expectedTextStyle = TextStyle(font: textStyle.font,
+                                          emFont: textStyle.emFont,
+                                          strongFont: textStyle.strongFont,
+                                          textColor: textStyle.textColor,
+                                          characterSpacing: textStyle.characterSpacing,
+                                          lineSpacing: textStyle.lineSpacing,
+                                          lineHeightMultiple: textStyle.lineHeightMultiple,
+                                          minimumLineHeight: textStyle.minimumLineHeight,
+                                          maximumLineHeight: textStyle.maximumLineHeight,
+                                          firstLineHeadIndent: textStyle.firstLineHeadIndent,
+                                          headIndent: textStyle.headIndent,
+                                          paragraphSpacing: textStyle.paragraphSpacing,
+                                          paragraphSpacingBefore: textStyle.paragraphSpacingBefore,
+                                          textAlignment: textStyle.textAlignment,
+                                          lineBreakMode: textStyle.lineBreakMode,
+                                          strikethroughStyle: textStyle.strikethroughStyle,
+                                          strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: newUnderlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -488,6 +578,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: newTextTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -513,6 +605,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -537,6 +631,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)
@@ -561,6 +657,8 @@ class TextStyleFactoryFunctionTests: XCTestCase {
                                           lineBreakMode: textStyle.lineBreakMode,
                                           strikethroughStyle: textStyle.strikethroughStyle,
                                           strikethroughColor: textStyle.strikethroughColor,
+                                          underlineStyle: textStyle.underlineStyle,
+                                          underlineColor: textStyle.underlineColor,
                                           textTransform: textStyle.textTransform)
         
         XCTAssertEqual(newTextStyle, expectedTextStyle)

--- a/Marker/Classes/Marker.swift
+++ b/Marker/Classes/Marker.swift
@@ -61,6 +61,7 @@ public func parsedMarkdownString(from markdownText: String,
     elements.forEach { (element) in
         var font: UIFont? = nil
         var strikethroughStyle: NSUnderlineStyle? = nil
+        var underlineStyle: NSUnderlineStyle? = nil
         
         switch element {
         case .em(_):
@@ -69,6 +70,8 @@ public func parsedMarkdownString(from markdownText: String,
             font = textStyle.strongFont
         case .strikethrough(_):
             strikethroughStyle = textStyle.strikethroughStyle
+        case .underline(_):
+            underlineStyle = textStyle.underlineStyle
         }
         
         if let font = font {
@@ -82,6 +85,14 @@ public func parsedMarkdownString(from markdownText: String,
             if let strikethroughColor = textStyle.strikethroughColor {
                 attributedString.addAttributes([NSStrikethroughColorAttributeName: strikethroughColor],
                                                range: parsedString.range(from: element.range))
+            }
+        }
+        
+        if let underlineStyle = underlineStyle {
+            attributedString.addAttributes([NSUnderlineStyleAttributeName: underlineStyle.rawValue], range: parsedString.range(from: element.range))
+            
+            if let underlineColor = textStyle.underlineColor {
+                attributedString.addAttributes([NSUnderlineColorAttributeName: underlineColor], range: parsedString.range(from: element.range))
             }
         }
     }

--- a/Marker/Classes/Parser/MarkdownElement.swift
+++ b/Marker/Classes/Parser/MarkdownElement.swift
@@ -13,11 +13,13 @@ import Foundation
 /// - em: Emphasis element.
 /// - strong: Strong element.
 /// - strikethrough: Strikethrough element.
+/// - underline: Underline element.
 internal enum MarkdownElement {
     
     case em(Range<Index>)
     case strong(Range<Index>)
     case strikethrough(Range<Index>)
+    case underline(Range<Index>)
     
     /// Range of characters that the elements apply to.
     var range: Range<Index> {
@@ -27,6 +29,8 @@ internal enum MarkdownElement {
         case .strong(let range):
             return range
         case .strikethrough(let range):
+            return range
+        case .underline(let range):
             return range
         }
     }

--- a/Marker/Classes/Parser/MarkdownParser.swift
+++ b/Marker/Classes/Parser/MarkdownParser.swift
@@ -27,6 +27,7 @@ internal struct MarkdownParser {
     private static let underscoreStrongSymbol = Symbol(rawValue: "__")
     private static let asteriskStrongSymbol = Symbol(rawValue: "**")
     private static let tildeStrikethroughSymbol = Symbol(rawValue: "~~")
+    private static let equalUnderlineSymbol = Symbol(rawValue: "==")
     
     // MARK: - Static functions
     
@@ -41,7 +42,8 @@ internal struct MarkdownParser {
             let asteriskEmSymbol = asteriskEmSymbol,
             let underscoreStrongSymbol = underscoreStrongSymbol,
             let asteriskStrongSymbol = asteriskStrongSymbol,
-            let tildeStrikethroughSymbol = tildeStrikethroughSymbol else {
+            let tildeStrikethroughSymbol = tildeStrikethroughSymbol,
+            let equalUnderlineSymbol = equalUnderlineSymbol else {
                 return (string, [])
         }
         
@@ -53,6 +55,8 @@ internal struct MarkdownParser {
                 return .strong(element.range)
             case tildeStrikethroughSymbol:
                 return .strikethrough(element.range)
+            case equalUnderlineSymbol:
+                return .underline(element.range)
             default:
                 throw ParserError.invalidTagSymbol
             }
@@ -63,7 +67,8 @@ internal struct MarkdownParser {
                                                                        asteriskEmSymbol,
                                                                        underscoreStrongSymbol,
                                                                        asteriskStrongSymbol,
-                                                                       tildeStrikethroughSymbol])
+                                                                       tildeStrikethroughSymbol,
+                                                                       equalUnderlineSymbol])
         return try (strippedString, elements.map(transformToMarkdownElement))
     }
     

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -126,6 +126,17 @@ public extension TextStyle {
         return self.with(newFont: emFont)
     }
     
+    /// Creates new Text Style from exisiting TextStyle, with underline.
+    ///
+    /// - Parameter color: Underline color. Defaults to textColor.
+    /// - Parameter style: Underline style. Defaults to single line.
+    /// - Returns: New TextStyle with underline.
+    public func underlined(color: UIColor? = nil, style: NSUnderlineStyle = .styleSingle) -> TextStyle {
+        return self
+            .with(newUnderlineStyle: style)
+            .with(newUnderlineColor: color ?? textColor)
+    }
+    
 }
 
 // MARK: - Protocol conformance

--- a/Marker/Classes/TextStyle+Extensions.swift
+++ b/Marker/Classes/TextStyle+Extensions.swift
@@ -31,6 +31,8 @@ public extension TextStyle {
     ///   - newLineBreakMode: New line break mode.
     ///   - newStrikethroughStyle: New strikethrough style.
     ///   - newStrikethroughColor: New strikethrough color.
+    ///   - newUnderlineStyle: New underline style.
+    ///   - newUnderlineColor: New underline color.
     ///   - newTextTransform: New text transform.
     /// - Returns: New Text Style with updated value(s).
     public func with(newFont: UIFont? = nil,
@@ -50,6 +52,8 @@ public extension TextStyle {
                      newLineBreakMode: NSLineBreakMode? = nil,
                      newStrikethroughStyle: NSUnderlineStyle? = nil,
                      newStrikethroughColor: UIColor? = nil,
+                     newUnderlineStyle: NSUnderlineStyle? = nil,
+                     newUnderlineColor: UIColor? = nil,
                      newTextTransform: TextTransform? = nil) -> TextStyle {
         let fontToUse = (newFont == nil) ? self.font : newFont!
         let emFontToUse = (newEmFont == nil) ? self.emFont : newEmFont!
@@ -68,6 +72,8 @@ public extension TextStyle {
         let lineBreakModeToUse = (newLineBreakMode == nil) ? self.lineBreakMode : newLineBreakMode!
         let strikethroughStyleToUse = (newStrikethroughStyle == nil) ? self.strikethroughStyle : newStrikethroughStyle!
         let strikethroughColorToUse = (newStrikethroughColor == nil) ? self.strikethroughColor : newStrikethroughColor!
+        let underlineStyleToUse = (newUnderlineStyle == nil) ? self.underlineStyle : newUnderlineStyle!
+        let underlineColorToUse = (newUnderlineColor == nil) ? self.underlineColor : newUnderlineColor!
         let textTransformToUse = (newTextTransform == nil) ? self.textTransform : newTextTransform!
         
         return TextStyle(
@@ -88,6 +94,8 @@ public extension TextStyle {
             lineBreakMode: lineBreakModeToUse,
             strikethroughStyle: strikethroughStyleToUse,
             strikethroughColor: strikethroughColorToUse,
+            underlineStyle: underlineStyleToUse,
+            underlineColor: underlineColorToUse,
             textTransform: textTransformToUse
         )
     }
@@ -144,6 +152,8 @@ public func ==(lhs: TextStyle, rhs: TextStyle) -> Bool {
         lhs.lineBreakMode == rhs.lineBreakMode,
         lhs.strikethroughStyle == rhs.strikethroughStyle,
         lhs.strikethroughColor == rhs.strikethroughColor,
+        lhs.underlineStyle == rhs.underlineStyle,
+        lhs.underlineColor == rhs.underlineColor,
         lhs.textTransform == rhs.textTransform else {
         return false
     }

--- a/Marker/Classes/TextStyle.swift
+++ b/Marker/Classes/TextStyle.swift
@@ -67,6 +67,12 @@ public struct TextStyle {
     /// Stroke color for strikethough text.
     public var strikethroughColor: UIColor?
     
+    /// Underline style for underlined text.s
+    public var underlineStyle: NSUnderlineStyle?
+    
+    /// Stroke color for underlined text.
+    public var underlineColor: UIColor?
+    
     /// Text transform.
     public var textTransform: TextTransform
     
@@ -145,6 +151,8 @@ public struct TextStyle {
      - parameter lineBreakMode:          Line break node.
      - parameter strikethroughStyle:     Strikethrough style.
      - parameter strikethroughColor:     Strikethrough color.
+     - parameter underlineStyle:         Underline style.
+     - parameter underlineColor:         Underline color.s
      - parameter textTransform:          Text transform option.
      
      - returns: An initialized text style object.
@@ -166,6 +174,8 @@ public struct TextStyle {
                 lineBreakMode: NSLineBreakMode? = nil,
                 strikethroughStyle: NSUnderlineStyle? = nil,
                 strikethroughColor: UIColor? = nil,
+                underlineStyle: NSUnderlineStyle? = nil,
+                underlineColor: UIColor? = nil,
                 textTransform: TextTransform = .none) {
         self.font = font
         self.emFont = (emFont == nil) ? font : emFont!
@@ -184,6 +194,8 @@ public struct TextStyle {
         self.lineBreakMode = lineBreakMode
         self.strikethroughStyle = strikethroughStyle
         self.strikethroughColor = strikethroughColor
+        self.underlineStyle = underlineStyle
+        self.underlineColor = underlineColor
         self.textTransform = textTransform
     }
 }

--- a/Marker/Classes/TextStyle.swift
+++ b/Marker/Classes/TextStyle.swift
@@ -152,7 +152,7 @@ public struct TextStyle {
      - parameter strikethroughStyle:     Strikethrough style.
      - parameter strikethroughColor:     Strikethrough color.
      - parameter underlineStyle:         Underline style.
-     - parameter underlineColor:         Underline color.s
+     - parameter underlineColor:         Underline color.
      - parameter textTransform:          Text transform option.
      
      - returns: An initialized text style object.

--- a/Marker/Classes/TextStyle.swift
+++ b/Marker/Classes/TextStyle.swift
@@ -67,7 +67,7 @@ public struct TextStyle {
     /// Stroke color for strikethough text.
     public var strikethroughColor: UIColor?
     
-    /// Underline style for underlined text.s
+    /// Underline style for underlined text.
     public var underlineStyle: NSUnderlineStyle?
     
     /// Stroke color for underlined text.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Marker also supports setting text with common Markdown tags:
 
 * Bold (`__` or `**`)
 * Italic (`_` or `*`)
+
+As well as convenient Markdown tags specific to Marker:
+
 * Strikethrough (`~~`)
 * Underline (`==`)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Marker abstracts the most common attributed text properties into a data object c
 * Text alignment
 * Line break mode
 * Strikethrough style and color
+* Underline style and color
 * Text transformation option
 
 `TextStyle` objects are a simple way of aggregating style information. For example:
@@ -94,6 +95,7 @@ Marker also supports setting text with common Markdown tags:
 * Bold (`__` or `**`)
 * Italic (`_` or `*`)
 * Strikethrough (`~~`)
+* Underline (`==`)
 
 To set Markdown text on these elements, use `setMarkdownText(_:using:)` (or `setMarkdownTitleText(_:using:)` for `UIButton`) function.
 


### PR DESCRIPTION
* Added support for new Markdown tag - `==` for underlining
* Added `underlineStyle` and `underlineColor` to `TextStyle`
* Updated `TextStyle` factory functions to include new properties
* Tests