### PR TITLE
Added a new link marker to manage in-app links

### DIFF
--- a/Marker/Marker/Marker.swift
+++ b/Marker/Marker/Marker.swift
@@ -98,6 +98,13 @@ public func parsedMarkdownString(from markdownText: String,
                                               value: linkFont,
                                               range: NSRange(range, in: parsedString))
             }
+        case .inAppLink(let range):
+            font = textStyle.strongFont
+            if let linkColor = textStyle.linkColor {
+                attributedString.addAttribute(AttributedStringKey.foregroundColor,
+                                              value: linkColor,
+                                              range: NSRange(range, in: parsedString))
+            }
         }
         
         if let font = font {

--- a/Marker/Marker/Parser/MarkdownElement.swift
+++ b/Marker/Marker/Parser/MarkdownElement.swift
@@ -22,11 +22,12 @@ enum MarkdownElement {
     case strikethrough(range: Range<Index>)
     case underline(range: Range<Index>)
     case link(range: Range<Index>, urlString: String)
+    case inAppLink(range: Range<Index>)
     
     /// Range of characters that the elements apply to.
     var range: Range<Index> {
         switch self {
-        case .em(let range), .strong(let range), .strikethrough(let range), .underline(let range), .link(let range, _):
+        case .em(let range), .strong(let range), .strikethrough(let range), .underline(let range), .link(let range, _), .inAppLink(let range):
             return range
         }
     }

--- a/Marker/Marker/Parser/MarkdownParser.swift
+++ b/Marker/Marker/Parser/MarkdownParser.swift
@@ -32,6 +32,7 @@ struct MarkdownParser {
     private static let linkTextClosingSymbol = Symbol(character: "]")
     private static let linkURLOpeningSymbol = Symbol(character: "(")
     private static let linkURLClosingSymbol = Symbol(character: ")")
+    private static let inAppLinkSymbol = Symbol(rawValue: "--")
     
     // MARK: - Static functions
     
@@ -45,7 +46,8 @@ struct MarkdownParser {
             let underscoreStrongSymbol = underscoreStrongSymbol,
             let asteriskStrongSymbol = asteriskStrongSymbol,
             let tildeStrikethroughSymbol = tildeStrikethroughSymbol,
-            let equalUnderlineSymbol = equalUnderlineSymbol else {
+            let equalUnderlineSymbol = equalUnderlineSymbol,
+            let inAppLinkSymbol = inAppLinkSymbol else {
                 return (string, [])
         }
 
@@ -57,6 +59,7 @@ struct MarkdownParser {
         let equalUnderlineRule = Rule(symbol: equalUnderlineSymbol)
         let linkTextRule = Rule(openingSymbol: linkTextOpeningSymbol, closingSymbol: linkTextClosingSymbol)
         let linkURLRule = Rule(openingSymbol: linkURLOpeningSymbol, closingSymbol: linkURLClosingSymbol)
+        let inAppLinkRule = Rule(symbol: inAppLinkSymbol)
 
         let tokens = try TokenParser.parse(string,
                                            using: [underscoreEmRule,
@@ -66,7 +69,8 @@ struct MarkdownParser {
                                                    tildeStrikethroughRule,
                                                    equalUnderlineRule,
                                                    linkTextRule,
-                                                   linkURLRule])
+                                                   linkURLRule,
+                                                   inAppLinkRule])
 
         guard tokens.count > 0 else {
             return (string, [])
@@ -105,6 +109,9 @@ struct MarkdownParser {
                 elements.append(.link(range: range,urlString: tokens[i + 1].string))
 
                 i += 1
+            case .some(inAppLinkRule):
+                let range = strippedString.append(contentOf: token)
+                elements.append(.inAppLink(range: range))
             default:
                 strippedString += token.stringWithRuleSymbols
             }


### PR DESCRIPTION
- In-app links are displayed with a strong weight and an accent color
- Added a custom symbol `--` to manage the markdown
eg: `Hello --World--`
Hello **World**

So the word `World` will be bold and with a link color.